### PR TITLE
Do not break webshop when Picqer is not reachable

### DIFF
--- a/Observer/SendWebhook.php
+++ b/Observer/SendWebhook.php
@@ -38,6 +38,11 @@ class SendWebhook implements ObserverInterface
         $orderData['picqer_magento_key'] = $magentoKey;
 
         $this->_curl->addHeader("Content-Type", "application/json");
-        $this->_curl->post('https://' . $subDomain . '.picqer.com/webshops/magento2/orderPush/' . $magentoKey, json_encode($orderData));
+        $this->_curl->setTimeout(1000);
+        try {
+            $this->_curl->post('https://' . $subDomain . '.picqer.com/webshops/magento2/orderPush/' . $magentoKey, json_encode($orderData));
+        } catch (\Exception $e) {
+            // Failed to deliver webhook, Picqer will import this order on next pull
+        }
     }
 }

--- a/Observer/SendWebhook.php
+++ b/Observer/SendWebhook.php
@@ -8,13 +8,16 @@ class SendWebhook implements ObserverInterface
 {
     protected $_scopeConfig;
     protected $_curl;
+    protected $_logger;
 
     public function __construct(
         \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
-        \Magento\Framework\HTTP\Client\Curl $curl
+        \Magento\Framework\HTTP\Client\Curl $curl,
+        \Psr\Log\LoggerInterface $logger
     ) {
         $this->_scopeConfig = $scopeConfig;
         $this->_curl = $curl;
+        $this->_logger = $logger;
     }
 
     public function execute(\Magento\Framework\Event\Observer $observer)
@@ -43,8 +46,7 @@ class SendWebhook implements ObserverInterface
         try {
             $this->_curl->post('https://' . trim($subDomain) . '.picqer.com/webshops/magento2/orderPush/' . trim($magentoKey), json_encode($orderData));
         } catch (\Exception $e) {
-            // Failed to deliver webhook, Picqer will import this order on next pull
-            // Log to Magento log (if enabled)
+            $this->_logger->debug('Exception occurred with Picqer: ' . $e->getMessage());
         }
     }
 }

--- a/Observer/SendWebhook.php
+++ b/Observer/SendWebhook.php
@@ -38,7 +38,7 @@ class SendWebhook implements ObserverInterface
         $orderData['picqer_magento_key'] = $magentoKey;
 
         $this->_curl->addHeader("Content-Type", "application/json");
-        $this->_curl->setTimeout(500);
+        $this->_curl->setTimeout(2000);
         try {
             $this->_curl->post('https://' . $subDomain . '.picqer.com/webshops/magento2/orderPush/' . $magentoKey, json_encode($orderData));
         } catch (\Exception $e) {

--- a/Observer/SendWebhook.php
+++ b/Observer/SendWebhook.php
@@ -38,7 +38,7 @@ class SendWebhook implements ObserverInterface
         $orderData['picqer_magento_key'] = $magentoKey;
 
         $this->_curl->addHeader("Content-Type", "application/json");
-        $this->_curl->setTimeout(1000);
+        $this->_curl->setTimeout(300);
         try {
             $this->_curl->post('https://' . $subDomain . '.picqer.com/webshops/magento2/orderPush/' . $magentoKey, json_encode($orderData));
         } catch (\Exception $e) {

--- a/Observer/SendWebhook.php
+++ b/Observer/SendWebhook.php
@@ -38,7 +38,7 @@ class SendWebhook implements ObserverInterface
         $orderData['picqer_magento_key'] = $magentoKey;
 
         $this->_curl->addHeader("Content-Type", "application/json");
-        $this->_curl->setTimeout(300);
+        $this->_curl->setTimeout(500);
         try {
             $this->_curl->post('https://' . $subDomain . '.picqer.com/webshops/magento2/orderPush/' . $magentoKey, json_encode($orderData));
         } catch (\Exception $e) {

--- a/Observer/SendWebhook.php
+++ b/Observer/SendWebhook.php
@@ -40,9 +40,10 @@ class SendWebhook implements ObserverInterface
         $this->_curl->addHeader("Content-Type", "application/json");
         $this->_curl->setTimeout(2000);
         try {
-            $this->_curl->post('https://' . $subDomain . '.picqer.com/webshops/magento2/orderPush/' . $magentoKey, json_encode($orderData));
+            $this->_curl->post('https://' . trim($subDomain) . '.picqer.com/webshops/magento2/orderPush/' . trim($magentoKey), json_encode($orderData));
         } catch (\Exception $e) {
             // Failed to deliver webhook, Picqer will import this order on next pull
+            // Log to Magento log (if enabled)
         }
     }
 }

--- a/Observer/SendWebhook.php
+++ b/Observer/SendWebhook.php
@@ -38,7 +38,8 @@ class SendWebhook implements ObserverInterface
         $orderData['picqer_magento_key'] = $magentoKey;
 
         $this->_curl->addHeader("Content-Type", "application/json");
-        $this->_curl->setTimeout(2000);
+        // Set timeout for 2 seconds
+        $this->_curl->setTimeout(2);
         try {
             $this->_curl->post('https://' . trim($subDomain) . '.picqer.com/webshops/magento2/orderPush/' . trim($magentoKey), json_encode($orderData));
         } catch (\Exception $e) {

--- a/Observer/SendWebhook.php
+++ b/Observer/SendWebhook.php
@@ -43,9 +43,9 @@ class SendWebhook implements ObserverInterface
         $this->_curl->addHeader("Content-Type", "application/json");
         $this->_curl->setTimeout(2); // in seconds
         try {
-            $this->_curl->post('https://' . trim($subDomain) . '.picqer.com/webshops/magento2/orderPush/' . trim($magentoKey), json_encode($orderData));
+            $this->_curl->post(sprintf('https://%s.picqer.com/webshops/magento2/orderPush/%s', trim($subDomain), trim($magentoKey)), json_encode($orderData));
         } catch (\Exception $e) {
-            $this->_logger->debug('Exception occurred with Picqer: ' . $e->getMessage());
+            $this->_logger->debug(sprintf('Exception occurred with Picqer: %s', $e->getMessage()));
         }
     }
 }

--- a/Observer/SendWebhook.php
+++ b/Observer/SendWebhook.php
@@ -41,8 +41,7 @@ class SendWebhook implements ObserverInterface
         $orderData['picqer_magento_key'] = $magentoKey;
 
         $this->_curl->addHeader("Content-Type", "application/json");
-        // Set timeout for 2 seconds
-        $this->_curl->setTimeout(2);
+        $this->_curl->setTimeout(2); // in seconds
         try {
             $this->_curl->post('https://' . trim($subDomain) . '.picqer.com/webshops/magento2/orderPush/' . trim($magentoKey), json_encode($orderData));
         } catch (\Exception $e) {

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "picqer/magento2-plugin",
   "description": "Picqer Extended Integration for Magento 2",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "type": "magento2-module",
   "keywords": [
     "picqer",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Picqer_Integration" setup_version="1.0.1">
+    <module name="Picqer_Integration" setup_version="1.0.2">
         <sequence>
             <module name="Magento_Webapi" />
         </sequence>


### PR DESCRIPTION
When a request takes a long time, or Picqer is not reachable for the shop, the plugin causes the order saving transaction in Magento to be interrupted. 

This change sets a time out for requests to 2 seconds and adds a try/catch to prevent curl errors to stop the save of an order in Magento. 