### PR TITLE
Fix: Headers en opties van een vorige request worden gebruikt.

### DIFF
--- a/Observer/SendWebhook.php
+++ b/Observer/SendWebhook.php
@@ -40,8 +40,14 @@ class SendWebhook implements ObserverInterface
         $orderData['increment_id'] = $order->getIncrementId();
         $orderData['picqer_magento_key'] = $magentoKey;
 
-        $this->_curl->addHeader("Content-Type", "application/json");
-        $this->_curl->setTimeout(2); // in seconds
+        $this->_curl->setHeaders(
+            'Content-Type', 'application/json'
+        );
+
+        $this->_curl->setOptions([
+            CURLOPT_TIMEOUT => 30 // in seconds
+        ]);
+
         try {
             $this->_curl->post(sprintf('https://%s.picqer.com/webshops/magento2/orderPush/%s', trim($subDomain), trim($magentoKey)), json_encode($orderData));
         } catch (\Exception $e) {

--- a/Observer/SendWebhook.php
+++ b/Observer/SendWebhook.php
@@ -40,9 +40,9 @@ class SendWebhook implements ObserverInterface
         $orderData['increment_id'] = $order->getIncrementId();
         $orderData['picqer_magento_key'] = $magentoKey;
 
-        $this->_curl->setHeaders(
-            'Content-Type', 'application/json'
-        );
+        $this->_curl->setHeaders([
+            'Content-Type' => 'application/json'
+        ]);
 
         $this->_curl->setOptions([
             CURLOPT_TIMEOUT => 2 // in seconds

--- a/Observer/SendWebhook.php
+++ b/Observer/SendWebhook.php
@@ -45,7 +45,7 @@ class SendWebhook implements ObserverInterface
         );
 
         $this->_curl->setOptions([
-            CURLOPT_TIMEOUT => 30 // in seconds
+            CURLOPT_TIMEOUT => 2 // in seconds
         ]);
 
         try {

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "picqer/magento2-plugin",
   "description": "Picqer Extended Integration for Magento 2",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "type": "magento2-module",
   "keywords": [
     "picqer",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Picqer_Integration" setup_version="1.0.2">
+    <module name="Picqer_Integration" setup_version="1.0.3">
         <sequence>
             <module name="Magento_Webapi" />
         </sequence>


### PR DESCRIPTION
[link naar front](https://app.frontapp.com/inboxes/teams/folders/4031944/open/33176634440)

### Probleem of aanleiding
- De send webhook kreeg een timeout en/of faalde wanneer de `squeezely/magento2-plugin` plugin werd geinstalleerd/geactiveerd.
- Dit komt omdat de Magento CURL client een singleton is en de Squeezely plugin headers en options zet met de `setHeaders` en `setOptions` functies van de Magento CURL client. Om deze te overschrijven moet een andere gebruiker van de Magento CURL client ook deze functies aanroepen of een andere instance gebruiken.
- De Picqer magento plugin gebruik de setOption en addHeader functies. Daarbij worden dus alleen opties en headers toegevoegd. Oude headers en opties blijven intact.

### Oplossing
- De Picqer Magento plugin moet gebruik gaan maken van de `setHeaders` en `setOptions` om een schone lei te hebben.

### Gevolgen en compatibility
- Gebruikers van de plugin moeten upgraden naar 1.0.3

### Twijfels
- De aanpassingen zijn getest door een klant, door deze live aan te passen. Ik heb de aanpassingen zelf niet kunnen testen. Ik heb wel een poging gewaagd door een lokale Meganto installatie op te zetten. Maar op een gegeven moment koste dit te veel tijd.

### Checklist
- [x] Is het originele doel bereikt?
- [x] Zijn alle losse eindjes opgelost?
- [ ] Heb je tests toegevoegd?
- [x] Is het duidelijk voor de gebruiker, qua werking en design?
- [ ] Is documentatie bijgewerkt? Online of intern.
- [ ] Worden fouten en vreemde situaties in de code afgehandeld?

[Deploy checklist](https://3.basecamp.com/3093964/buckets/887645/documents/2256881769)

