### PR TITLE
Push orders by cron

### DIFF
--- a/Api/Data/PushOrderMetadataInterface.php
+++ b/Api/Data/PushOrderMetadataInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Picqer\Integration\Api\Data;
+
+interface PushOrderMetadataInterface
+{
+    const STATUS_PROCESSED = 1;
+    const STATUS_UNPROCESSED = 0;
+
+    const COLUMN_ID = 'id';
+    const COLUMN_ORDER_ID = 'order_id';
+    const COLUMN_ORDER_STATUS = 'order_status';
+    const COLUMN_MESSAGE = 'message';
+    const COLUMN_STATUS = 'status';
+    const COLUMN_CREATED_AT = 'created_at';
+
+    public function getId();
+
+    public function getOrderId();
+
+    public function getCreatedAt();
+
+    public function setOrderId($orderId);
+
+    public function setOrderStatus($orderStatus);
+
+    public function setStatus($status);
+
+    public function setMessage($message);
+
+}

--- a/Api/PushOrderMetadataRepositoryInterface.php
+++ b/Api/PushOrderMetadataRepositoryInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Picqer\Integration\Api;
+
+use Picqer\Integration\Api\Data\PushOrderMetadataInterface;
+
+/**
+ * @api
+ */
+interface PushOrderMetadataRepositoryInterface
+{
+    /**
+     * @param PushOrderMetadataInterface $pushOrderMetadata
+     * @return mixed
+     */
+    function setProcessed(PushOrderMetadataInterface $pushOrderMetadata, $message);
+
+    /**
+     * @return PushOrderMetadataInterface[]
+     */
+    function getUnprocessedList();
+
+    function save(PushOrderMetadataInterface $pushOrderMetadata);
+}

--- a/Cron/PushOrder.php
+++ b/Cron/PushOrder.php
@@ -86,8 +86,14 @@ class PushOrder
         $orderData['increment_id'] = $order->getIncrementId();
         $orderData['picqer_magento_key'] = $magentoKey;
 
-        $this->_curl->addHeader("Content-Type", "application/json");
-        $this->_curl->setTimeout(2); // in seconds
+        $this->_curl->setHeaders([
+            'Content-Type' => 'application/json'
+        ]);
+    
+        $this->_curl->setOptions([
+            CURLOPT_TIMEOUT => 2 // in seconds
+        ]);
+
         $this->_curl->post(sprintf('https://%s.picqer.com/webshops/magento2/orderPush/%s', trim($subDomain), trim($magentoKey)), json_encode($orderData));
 
         return $this->_curl->getBody();

--- a/Cron/PushOrder.php
+++ b/Cron/PushOrder.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Picqer\Integration\Cron;
+
+use Exception;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\HTTP\Client\Curl;
+use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\Store\Model\ScopeInterface;
+use Picqer\Integration\Api\PushOrderMetadataRepositoryInterface;
+use Psr\Log\LoggerInterface;
+
+class PushOrder
+{
+    const XML_PATH_ENABLED = 'picqer_integration_options/webhook_settings/cron_enabled';
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+    /**
+     * @var ScopeConfigInterface
+     */
+    private $scopeConfig;
+    /**
+     * @var PushOrderMetadataRepositoryInterface
+     */
+    private $pushOrderMetadataRepository;
+    /**
+     * @var Curl
+     */
+    private $_curl;
+    /**
+     * @var OrderRepositoryInterface
+     */
+    private $orderRepository;
+
+    public function __construct(
+        LoggerInterface $logger,
+        PushOrderMetadataRepositoryInterface $pushOrderMetadataRepository,
+        OrderRepositoryInterface $orderRepository,
+        Curl $_curl,
+        ScopeConfigInterface $scopeConfig
+    )
+    {
+        $this->logger = $logger;
+        $this->scopeConfig = $scopeConfig;
+        $this->pushOrderMetadataRepository = $pushOrderMetadataRepository;
+        $this->_curl = $_curl;
+        $this->orderRepository = $orderRepository;
+    }
+
+    public function execute()
+    {
+        if (!$this->scopeConfig->getValue(self::XML_PATH_ENABLED,ScopeInterface::SCOPE_STORE)) {
+            return $this;
+        }
+        $timeToCompare = date("Y-m-d H:i:s", strtotime('-1 days'));
+        foreach ($this->pushOrderMetadataRepository->getUnprocessedList() as $pushOrderMetadata) {
+            try {
+                if ($pushOrderMetadata->getCreatedAt() < $timeToCompare) {
+                    throw new Exception(sprintf("Too late for push: %s < %s", $pushOrderMetadata->getCreatedAt(), $timeToCompare));
+                }
+                $message = $this->pushOrder($pushOrderMetadata->getOrderId());
+            } catch (Exception $e) {
+                $this->logger->error("Picqer push order error: " . $e->getMessage());
+                $message = $e->getMessage();
+            }
+            $this->pushOrderMetadataRepository->setProcessed($pushOrderMetadata, $message);
+        }
+
+        return $this;
+    }
+
+    private function pushOrder($orderId)
+    {
+        $order = $this->orderRepository->get((int)$orderId);
+
+        $subDomain = $this->scopeConfig->getValue('picqer_integration_options/webhook_settings/picqer_subdomain');
+        $magentoKey = $this->scopeConfig->getValue('picqer_integration_options/webhook_settings/connection_key');
+
+        if (empty($subDomain) || empty($magentoKey)) {
+            throw new Exception("Module is not fully configured");
+        }
+
+        $orderData = [];
+        $orderData['increment_id'] = $order->getIncrementId();
+        $orderData['picqer_magento_key'] = $magentoKey;
+
+        $this->_curl->addHeader("Content-Type", "application/json");
+        $this->_curl->setTimeout(2); // in seconds
+        $this->_curl->post(sprintf('https://%s.picqer.com/webshops/magento2/orderPush/%s', trim($subDomain), trim($magentoKey)), json_encode($orderData));
+
+        return $this->_curl->getBody();
+    }
+
+}

--- a/Model/PushOrderMetadata.php
+++ b/Model/PushOrderMetadata.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Picqer\Integration\Model;
+
+use Magento\Framework\Model\AbstractModel;
+use Picqer\Integration\Api\Data\PushOrderMetadataInterface;
+use Picqer\Integration\Model\ResourceModel\PushOrderMetadata as Model;
+
+class PushOrderMetadata extends AbstractModel implements PushOrderMetadataInterface
+{
+    protected function _construct()
+    {
+        $this->_init(Model::class);
+    }
+
+    public function getId()
+    {
+        return $this->getData(PushOrderMetadataInterface::COLUMN_ID);
+    }
+
+    public function getOrderId()
+    {
+        return $this->getData(PushOrderMetadataInterface::COLUMN_ORDER_ID);
+    }
+
+    public function getCreatedAt()
+    {
+        return $this->getData(PushOrderMetadataInterface::COLUMN_CREATED_AT);
+    }
+
+    public function setOrderId($orderId)
+    {
+        $this->setData(PushOrderMetadataInterface::COLUMN_ORDER_ID, (int)$orderId);
+        return $this;
+    }
+
+    public function setOrderStatus($orderStatus)
+    {
+        $this->setData(PushOrderMetadataInterface::COLUMN_ORDER_STATUS, (string)$orderStatus);
+        return $this;
+    }
+
+    public function setStatus($status)
+    {
+        $this->setData(PushOrderMetadataInterface::COLUMN_STATUS, (int)$status);
+        return $this;
+    }
+
+    public function setMessage($message)
+    {
+        $this->setData(PushOrderMetadataInterface::COLUMN_MESSAGE, (string)$message);
+        return $this;
+    }
+
+}

--- a/Model/PushOrderMetadataRepository.php
+++ b/Model/PushOrderMetadataRepository.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Picqer\Integration\Model;
+
+use Magento\Framework\Exception\LocalizedException;
+use Picqer\Integration\Api\PushOrderMetadataRepositoryInterface;
+use Picqer\Integration\Api\Data\PushOrderMetadataInterface;
+use Picqer\Integration\Model\ResourceModel\PushOrderMetadata as ResourceModel;
+use Picqer\Integration\Model\PushOrderMetadataFactory as PushOrderMetadataFactory;
+use Picqer\Integration\Model\ResourceModel\PushOrderMetadata\CollectionFactory as CollectionFactory;
+use Picqer\Integration\Model\ResourceModel\PushOrderMetadata\Collection;
+
+class PushOrderMetadataRepository implements PushOrderMetadataRepositoryInterface
+{
+    /**
+     * @var ResourceModel
+     */
+    private $resourceModel;
+
+    /**
+     * @var CollectionFactory
+     */
+    private $collectionFactory;
+    /**
+     * @var PushOrderMetadataFactory
+     */
+    private $pushOrderMetadataFactory;
+
+    public function __construct(
+        ResourceModel $resourceModel,
+        PushOrderMetadataFactory $pushOrderMetadataFactory,
+        CollectionFactory $collectionFactory
+    )
+    {
+        $this->resourceModel = $resourceModel;
+        $this->collectionFactory = $collectionFactory;
+        $this->pushOrderMetadataFactory = $pushOrderMetadataFactory;
+    }
+
+    public function setProcessed(PushOrderMetadataInterface $pushOrderMetadata, $message)
+    {
+        $pushOrderMetadata->setMessage((string)$message);
+        $pushOrderMetadata->setStatus(PushOrderMetadataInterface::STATUS_PROCESSED);
+        return $this->save($pushOrderMetadata);
+    }
+
+    /**
+     * @param $id
+     * @return PushOrderMetadataInterface
+     * @throws LocalizedException
+     */
+    public function getById($id)
+    {
+        $model = $this->pushOrderMetadataFactory->create();
+        $this->resourceModel->load($model, (int)$id, PushOrderMetadataInterface::COLUMN_ID);
+        if (!$model->getId()) {
+            throw new LocalizedException(__('Unable to find item'));
+        }
+        return $model;
+    }
+
+    function getUnprocessedList()
+    {
+        $list = [];
+        /** @var Collection $collection */
+        $collection = $this->collectionFactory->create();
+        $collection->addFieldToFilter(PushOrderMetadataInterface::COLUMN_STATUS, ['eq' => PushOrderMetadataInterface::STATUS_UNPROCESSED]);
+        foreach ($collection as $item) {
+            $model = $this->getById((int)$item->getId());
+            $list[$model->getId()] = $model;
+        }
+        return $list;
+    }
+
+    function save(PushOrderMetadataInterface $pushOrderMetadata)
+    {
+        $this->resourceModel->save($pushOrderMetadata);
+        return $this->getById((int)$pushOrderMetadata->getId());
+    }
+}

--- a/Model/ResourceModel/PushOrderMetadata.php
+++ b/Model/ResourceModel/PushOrderMetadata.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Picqer\Integration\Model\ResourceModel;
+
+use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
+
+class PushOrderMetadata extends AbstractDb
+{
+    protected function _construct()
+    {
+        $this->_init('picqer_push_order_metadata', 'id');
+    }
+
+}

--- a/Model/ResourceModel/PushOrderMetadata/Collection.php
+++ b/Model/ResourceModel/PushOrderMetadata/Collection.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Picqer\Integration\Model\ResourceModel\PushOrderMetadata;
+
+use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
+use Picqer\Integration\Model\PushOrderMetadata as Model;
+use Picqer\Integration\Model\ResourceModel\PushOrderMetadata as ResourceModel;
+
+class Collection extends AbstractCollection
+{
+    protected function _construct()
+    {
+        $this->_init(Model::class, ResourceModel::class);
+    }
+}
+
+
+

--- a/Observer/CollectOrderSaveEvent.php
+++ b/Observer/CollectOrderSaveEvent.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Picqer\Integration\Observer;
+
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+use Picqer\Integration\Api\PushOrderMetadataRepositoryInterface;
+use Picqer\Integration\Cron\PushOrder;
+use Picqer\Integration\Api\Data\PushOrderMetadataInterface;
+use Picqer\Integration\Api\Data\PushOrderMetadataInterfaceFactory;
+use Psr\Log\LoggerInterface;
+
+class CollectOrderSaveEvent implements ObserverInterface
+{
+
+    /**
+     * @var ScopeConfigInterface
+     */
+    private $scopeConfig;
+    /**
+     * @var PushOrderMetadataInterfaceFactory
+     */
+    private $pushOrderMetadataInterfaceFactory;
+    /**
+     * @var PushOrderMetadataRepositoryInterface
+     */
+    private $pushOrderMetadataRepository;
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(
+        LoggerInterface $logger,
+        ScopeConfigInterface $scopeConfig,
+        PushOrderMetadataInterfaceFactory $pushOrderMetadataInterfaceFactory,
+        PushOrderMetadataRepositoryInterface $pushOrderMetadataRepository
+    ) {
+        $this->scopeConfig = $scopeConfig;
+        $this->pushOrderMetadataInterfaceFactory = $pushOrderMetadataInterfaceFactory;
+        $this->pushOrderMetadataRepository = $pushOrderMetadataRepository;
+        $this->logger = $logger;
+    }
+
+    public function execute(Observer $observer)
+    {
+        if (!$this->scopeConfig->isSetFlag(PushOrder::XML_PATH_ENABLED)) {
+            return;
+        }
+
+        try {
+            $order = $observer->getEvent()->getOrder();
+            /** @var PushOrderMetadataInterface $pushOrderMetadata */
+            $pushOrderMetadata = $this->pushOrderMetadataInterfaceFactory->create();
+            $pushOrderMetadata->setOrderId($order->getId());
+            $pushOrderMetadata->setOrderStatus($order->getStatus());
+            $this->pushOrderMetadataRepository->save($pushOrderMetadata);
+        } catch (\Exception $e) {
+            $this->logger->error("Can not create PushOrderMetadata instance: " . $e->getMessage());
+        }
+
+    }
+}

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -21,6 +21,13 @@
                 <field id="connection_key" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>Connection key</label>
                 </field>
+                <field id="cron_enabled" translate="label,comment" type="select" sortOrder="11" showInDefault="1"
+                       showInWebsite="1" showInStore="1">
+                    <label>Process by Cron</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <depends><field id="active">0</field></depends>
+                    <comment>Push orders to `Picqer` by cron instead `On Save Order`</comment>
+                </field>
             </group>
         </section>
     </system>

--- a/etc/cron_groups.xml
+++ b/etc/cron_groups.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Cron:etc/cron_groups.xsd">
+    <group id="picqer">
+        <schedule_generate_every>10</schedule_generate_every>
+        <schedule_ahead_for>20</schedule_ahead_for>
+        <schedule_lifetime>10</schedule_lifetime>
+        <history_cleanup_every>10</history_cleanup_every>
+        <history_success_lifetime>60</history_success_lifetime>
+        <history_failure_lifetime>600</history_failure_lifetime>
+        <use_separate_process>1</use_separate_process>
+    </group>
+</config>

--- a/etc/crontab.xml
+++ b/etc/crontab.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Cron:etc/crontab.xsd">
+    <group id="picqer">
+        <job name="picqer_push_orders" instance="Picqer\Integration\Cron\PushOrder" method="execute">
+            <schedule>* * * * *</schedule>
+        </job>
+    </group>
+</config>

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+
+<schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Setup/Declaration/Schema/etc/schema.xsd">
+
+    <table name="picqer_push_order_metadata" resource="default">
+        <column name="id" xsi:type="int" padding="10" unsigned="true" nullable="false" identity="true" comment="ID"/>
+        <column name="order_id" xsi:type="int" padding="11" comment="order id"/>
+        <column name="order_status" xsi:type="varchar" length="255" nullable="false" default="" comment="order status"/>
+        <column name="message" xsi:type="text" comment="message"/>
+        <column name="created_at" xsi:type="timestamp" default="CURRENT_TIMESTAMP" on_update="false"/>
+        <column name="updated_at" xsi:type="timestamp" default="CURRENT_TIMESTAMP" on_update="true"/>
+        <column name="status" xsi:type="tinyint" padding="2" default="0" comment="status"/>
+        <constraint xsi:type="primary" referenceId="PRIMARY">
+            <column name="id"/>
+        </constraint>
+        <index referenceId="order_id_index" indexType="btree">
+            <column name="order_id"/>
+        </index>
+        <index referenceId="processing_status_index" indexType="btree">
+            <column name="status"/>
+        </index>
+    </table>
+
+</schema>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+
+    <preference for="Picqer\Integration\Api\Data\PushOrderMetadataInterface" type="Picqer\Integration\Model\PushOrderMetadata" />
+    <preference for="Picqer\Integration\Api\PushOrderMetadataRepositoryInterface" type="Picqer\Integration\Model\PushOrderMetadataRepository" />
+
+</config>

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -2,5 +2,6 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
     <event name="sales_order_save_after">
         <observer name="picqer_webhooks_sales_order_save_after" instance="Picqer\Integration\Observer\SendWebhook" />
+        <observer name="picqer_collect_order_save_event" instance="Picqer\Integration\Observer\CollectOrderSaveEvent" />
     </event>
 </config>


### PR DESCRIPTION
This functionality was implemented because we had problems with nested transactions for the Piqer module and payment module.

Payment module use event sales_order_save_commit_after for push order
Picqer module use event sales_order_save_after for push order

I add possibility to process order to the Picqer in the separate flow by cron every minute (this mode is possible to enable when normal way of working by events is disabled)

Qlicks B.V.